### PR TITLE
Fix OK button enabled on new game dialog for empty case

### DIFF
--- a/GamebookEngine/Views/Game List/GameListTableViewController.swift
+++ b/GamebookEngine/Views/Game List/GameListTableViewController.swift
@@ -126,9 +126,10 @@ extension GameListTableViewController: GameListGameTableViewCellDelegate, UIDocu
             textField.autocapitalizationType = .words
             textField.placeholder = "A Magnificent Voyage"
         }
+        guard let textField = actionSheet.textFields?.first else { return }
 
         let okButton = UIAlertAction(title: "OK", style: .default) { _ in
-            guard let text = actionSheet.textFields?.first?.text, !text.isEmpty else { return }
+            guard let text = textField.text, !text.isEmpty else { return }
             GameDatabase.standard.createGame(name: text, completion: { game in
                 guard let game = game else { return }
                 DispatchQueue.main.async {
@@ -137,7 +138,13 @@ extension GameListTableViewController: GameListGameTableViewCellDelegate, UIDocu
                 }
             })
         }
+        okButton.isEnabled = false
         actionSheet.addAction(okButton)
+
+        NotificationCenter.default.addObserver(forName: UITextField.textDidChangeNotification, object: textField, queue: .main) { _ in
+            guard let text = textField.text else { return }
+            okButton.isEnabled = !text.isEmpty
+        }
 
         let cancelButton = UIAlertAction(title: "Cancel", style: .cancel, handler: nil)
         actionSheet.addAction(cancelButton)


### PR DESCRIPTION
## Summary
- Disables the OK button in the "New Game" dialog until at least one character is entered in the name field
- Observes `UITextField.textDidChangeNotification` on the alert's text field to toggle the button state
- Prevents creating a game with an empty name via the UI

## Test plan
- [ ] Tap `+` → "Create new game"
- [ ] Verify OK button is disabled when the text field is empty
- [ ] Type at least one character and verify OK button becomes enabled
- [ ] Clear the text field and verify OK button disables again
- [ ] Confirm a game is created successfully when a name is entered and OK is tapped

🤖 Generated with [Claude Code](https://claude.com/claude-code)