### PR TITLE
Fix File Import Failure

### DIFF
--- a/GamebookEngine.xcodeproj/project.pbxproj
+++ b/GamebookEngine.xcodeproj/project.pbxproj
@@ -536,7 +536,6 @@
 				B448874823063A0D000E2FDD /* Frameworks */,
 				B448874923063A0D000E2FDD /* Resources */,
 				4451A4BF232DCD36003D9FE9 /* Embed Foundation Extensions */,
-				44D767DD29DD3FF6001DFE82 /* Run Swiftlint */,
 			);
 			buildRules = (
 			);
@@ -560,7 +559,7 @@
 			attributes = {
 				BuildIndependentTargetsInParallel = YES;
 				LastSwiftUpdateCheck = 1100;
-				LastUpgradeCheck = 1430;
+				LastUpgradeCheck = 2600;
 				ORGANIZATIONNAME = "Brad Root";
 				TargetAttributes = {
 					4451A4B1232DCD36003D9FE9 = {
@@ -644,27 +643,6 @@
 			runOnlyForDeploymentPostprocessing = 0;
 		};
 /* End PBXResourcesBuildPhase section */
-
-/* Begin PBXShellScriptBuildPhase section */
-		44D767DD29DD3FF6001DFE82 /* Run Swiftlint */ = {
-			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputFileListPaths = (
-			);
-			inputPaths = (
-			);
-			name = "Run Swiftlint";
-			outputFileListPaths = (
-			);
-			outputPaths = (
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "export PATH=\"$PATH:/opt/homebrew/bin\"\nif which swiftlint > /dev/null; then\n  swiftlint\nelse\n  echo \"warning: SwiftLint not installed, download from https://github.com/realm/SwiftLint\"\nfi\n";
-		};
-/* End PBXShellScriptBuildPhase section */
 
 /* Begin PBXSourcesBuildPhase section */
 		4451A4AE232DCD36003D9FE9 /* Sources */ = {
@@ -764,7 +742,6 @@
 			buildSettings = {
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 15;
-				DEVELOPMENT_TEAM = 2Y9M69QJKZ;
 				INFOPLIST_FILE = GamebookPreviewExtension/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 13.6;
 				LD_RUNPATH_SEARCH_PATHS = (
@@ -785,7 +762,6 @@
 			buildSettings = {
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 15;
-				DEVELOPMENT_TEAM = 2Y9M69QJKZ;
 				INFOPLIST_FILE = GamebookPreviewExtension/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 13.6;
 				LD_RUNPATH_SEARCH_PATHS = (
@@ -837,8 +813,10 @@
 				CODE_SIGN_IDENTITY = "iPhone Developer";
 				COPY_PHASE_STRIP = NO;
 				DEBUG_INFORMATION_FORMAT = dwarf;
+				DEVELOPMENT_TEAM = 2Y9M69QJKZ;
 				ENABLE_STRICT_OBJC_MSGSEND = YES;
 				ENABLE_TESTABILITY = YES;
+				ENABLE_USER_SCRIPT_SANDBOXING = YES;
 				GCC_C_LANGUAGE_STANDARD = gnu11;
 				GCC_DYNAMIC_NO_PIC = NO;
 				GCC_NO_COMMON_BLOCKS = YES;
@@ -858,6 +836,7 @@
 				MTL_FAST_MATH = YES;
 				ONLY_ACTIVE_ARCH = YES;
 				SDKROOT = iphoneos;
+				STRING_CATALOG_GENERATE_SYMBOLS = YES;
 				SWIFT_ACTIVE_COMPILATION_CONDITIONS = DEBUG;
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
 			};
@@ -899,8 +878,10 @@
 				CODE_SIGN_IDENTITY = "iPhone Developer";
 				COPY_PHASE_STRIP = NO;
 				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				DEVELOPMENT_TEAM = 2Y9M69QJKZ;
 				ENABLE_NS_ASSERTIONS = NO;
 				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				ENABLE_USER_SCRIPT_SANDBOXING = YES;
 				GCC_C_LANGUAGE_STANDARD = gnu11;
 				GCC_NO_COMMON_BLOCKS = YES;
 				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
@@ -913,6 +894,7 @@
 				MTL_ENABLE_DEBUG_INFO = NO;
 				MTL_FAST_MATH = YES;
 				SDKROOT = iphoneos;
+				STRING_CATALOG_GENERATE_SYMBOLS = YES;
 				SWIFT_COMPILATION_MODE = wholemodule;
 				SWIFT_OPTIMIZATION_LEVEL = "-O";
 				VALIDATE_PRODUCT = YES;
@@ -922,12 +904,10 @@
 		B448877423063A0E000E2FDD /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
-				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_ENTITLEMENTS = GamebookEngine/GamebookEngine.entitlements;
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 15;
-				DEVELOPMENT_TEAM = 2Y9M69QJKZ;
 				INFOPLIST_FILE = GamebookEngine/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 13.6;
 				LD_RUNPATH_SEARCH_PATHS = (
@@ -947,12 +927,10 @@
 		B448877523063A0E000E2FDD /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
-				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_ENTITLEMENTS = GamebookEngine/GamebookEngine.entitlements;
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 15;
-				DEVELOPMENT_TEAM = 2Y9M69QJKZ;
 				INFOPLIST_FILE = GamebookEngine/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 13.6;
 				LD_RUNPATH_SEARCH_PATHS = (

--- a/GamebookEngine.xcodeproj/xcshareddata/xcschemes/GamebookEngine.xcscheme
+++ b/GamebookEngine.xcodeproj/xcshareddata/xcschemes/GamebookEngine.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1430"
+   LastUpgradeVersion = "2600"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/GamebookEngine.xcodeproj/xcshareddata/xcschemes/GamebookPreviewExtension.xcscheme
+++ b/GamebookEngine.xcodeproj/xcshareddata/xcschemes/GamebookPreviewExtension.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1430"
+   LastUpgradeVersion = "2600"
    wasCreatedForAppExtension = "YES"
    version = "2.0">
    <BuildAction

--- a/GamebookEngine/Views/Game List/GameListTableViewController.swift
+++ b/GamebookEngine/Views/Game List/GameListTableViewController.swift
@@ -299,7 +299,7 @@ extension GameListTableViewController: GameListGameTableViewCellDelegate, UIDocu
 
 // MARK: - Item Provider
 
-class GamebookProvider: UIActivityItemProvider {
+class GamebookProvider: UIActivityItemProvider, @unchecked Sendable {
     var temporaryURL: NSURL?
     var game: Game
 
@@ -323,7 +323,7 @@ class GamebookProvider: UIActivityItemProvider {
     }
 }
 
-class HTMLGamebookProvider: UIActivityItemProvider {
+class HTMLGamebookProvider: UIActivityItemProvider, @unchecked Sendable {
     var temporaryURL: NSURL?
     var game: Game
 

--- a/GamebookEngine/Views/Game List/GameListTableViewController.swift
+++ b/GamebookEngine/Views/Game List/GameListTableViewController.swift
@@ -101,8 +101,16 @@ extension GameListTableViewController: GameListGameTableViewCellDelegate, UIDocu
     func documentPicker(_: UIDocumentPickerViewController, didPickDocumentsAt urls: [URL]) {
         for url in urls {
             Log.info("Open URL: \(url)")
-            guard let jsonData = try? Data(contentsOf: url) else { continue }
-            GameSerializer.standard.gameFromJSONData(jsonData)
+            let didStartAccess = url.startAccessingSecurityScopedResource()
+            defer {
+                if didStartAccess { url.stopAccessingSecurityScopedResource() }
+            }
+            do {
+                let jsonData = try Data(contentsOf: url)
+                GameSerializer.standard.gameFromJSONData(jsonData)
+            } catch {
+                Log.error("Failed to read picked file at \(url): \(error)")
+            }
         }
     }
 


### PR DESCRIPTION
- fixes #56 – where on newer iOS versions, file import fails due to missing `startAccessingSecurityScopedResource` call.
- removes SwiftLint build phase which was supposed to be in #60 